### PR TITLE
Fix tests for cleaned up OpenDAP data types

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -16,4 +16,4 @@ def tests(session: nox.Session, pydantic: str):
     session.install("-r", "requirements-dev.txt")
     session.install(".")
     session.install(f"pydantic{pydantic}")
-    session.run("pytest", "--verbose")
+    session.run("pytest", "--verbose", *session.posargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ write_to = "xpublish_opendap/_version.py"
 [tool.check-manifest]
 ignore = ["xpublish_opendap/_version.py"]
 
-[tool.ruff]
+[tool.ruff.lint]
 select = [
     "A",   # flake8-builtins
     "B",   # flake8-bugbear
@@ -58,10 +58,15 @@ select = [
     "W",   # pycodestyle warnings
 ]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.extend-per-file-ignores]
+"tests/*" = [
+    "PLR2004"  # It's reasonable to use magic values in tests
+    ]
+
+[tool.ruff.lint.pydocstyle]
 # Use Google-style docstrings.
 convention = "google"
 
-[tool.ruff.flake8-bugbear]
+[tool.ruff.lint.flake8-bugbear]
 # Allow fastapi.Depends and other dependency injection style function arguments
 extend-immutable-calls = ["fastapi.Depends", "fastapi.Query"]

--- a/tests/test_opendap_router.py
+++ b/tests/test_opendap_router.py
@@ -33,7 +33,7 @@ def test_dds_response(dap_client):
     assert "Float32 time[time = 2920]" in content
     assert "Float32 lon[lon = 53]" in content
     assert "Grid {" in content
-    assert "Float32 air[time = 2920][lat = 25][lon = 53]" in content
+    assert "Float64 air[time = 2920][lat = 25][lon = 53]" in content
 
 
 def test_das_response(dap_client):
@@ -68,4 +68,4 @@ def test_dods_response(dap_client):
     assert "Float32 time[time = 2920]" in text_content
     assert "Float32 lon[lon = 53]" in text_content
     assert "Grid {" in text_content
-    assert "Float32 air[time = 2920][lat = 25][lon = 53]" in text_content
+    assert "Float64 air[time = 2920][lat = 25][lon = 53]" in text_content


### PR DESCRIPTION
Additionally fix pre-commit failures, and allow passing additional arguments into pytest/nox.